### PR TITLE
fix: HTML 리포트 생성 실패를 에러에서 워닝으로 변경

### DIFF
--- a/pactumjs_test_new/scripts/run-tests.js
+++ b/pactumjs_test_new/scripts/run-tests.js
@@ -412,8 +412,9 @@ class TestRunner {
         summary.htmlReportUrl = htmlReportUrl;
 
       } catch (error) {
-        logger.error(`Failed to generate/upload HTML report: ${error.message}`);
+        logger.warn(`Failed to generate/upload HTML report: ${error.message}`);
         // Don't throw - HTML report failure shouldn't break the test process
+        console.warn(`⚠️  HTML report generation failed: ${error.message}`);
       }
 
       // Upload to Google Sheets

--- a/pactumjs_test_new/src/data/test-case-loader.js
+++ b/pactumjs_test_new/src/data/test-case-loader.js
@@ -83,7 +83,7 @@ class TestCaseLoader {
           const row = data[i];
           if (row.length >= 5 && row[4]) {
             const testCase = {
-              testId: `${grade.toUpperCase()}_${row[1] || `${i}`}`,
+              testId: `${(grade || 'UNKNOWN').toUpperCase()}_${row[1] || `${i}`}`,
               userRole: 'User_S',
               userId: 'faq_user_001',
               category: row[2] || 'general',


### PR DESCRIPTION
## 개요
HTML 리포트 생성 실패 시 CI 파이프라인이 중단되는 문제를 해결합니다.

## 변경사항
- **scripts/run-tests.js**: `logger.error` → `logger.warn`으로 변경
- **src/data/test-case-loader.js**: `grade` undefined 에러 방지 로직 추가
- CI에서 HTML 리포트 생성 실패 시 워닝으로 처리하여 파이프라인 계속 진행

## 문제 해결
- ❌ 기존: HTML 리포트 생성 실패 시 CI 에러로 파이프라인 중단
- ✅ 수정: HTML 리포트 생성 실패 시 워닝 처리하고 테스트 계속 진행

## 테스트
- [x] 로컬에서 HTML 리포트 생성 실패 시나리오 확인
- [x] CI 파이프라인 중단되지 않는 것 확인

🤖 Generated with [Claude Code](https://claude.ai/code)