### PR TITLE
feat: GitHub Actions 워크플로우에 API 환경 선택 기능 추가

### DIFF
--- a/.github/workflows/pactum-tests.yml
+++ b/.github/workflows/pactum-tests.yml
@@ -25,6 +25,15 @@ on:
   # 수동 실행
   workflow_dispatch:
     inputs:
+      environment:
+        description: 'API 환경 선택'
+        required: true
+        type: choice
+        options:
+          - 'dev2'  # 개발 환경 2 (기본값)
+          - 'dev'   # 개발 환경 1
+        default: 'dev2'
+      
       test_type:
         description: '테스트 타입 선택'
         required: true
@@ -86,7 +95,7 @@ jobs:
     
     env:
       # API 환경 변수
-      AI_NAVI_CHAT_API_URL: ${{ secrets.AI_NAVI_CHAT_API_URL || 'https://67hnjuna66.execute-api.ap-northeast-1.amazonaws.com/prd-1' }}
+      AI_NAVI_CHAT_API_URL: ${{ github.event.inputs.environment == 'dev' && 'https://67hnjuna66.execute-api.ap-northeast-1.amazonaws.com/prd-1' || 'https://67hnjuna66.execute-api.ap-northeast-1.amazonaws.com/dev2' }}
       AI_NAVI_CHAT_API_KEY: ${{ secrets.AI_NAVI_CHAT_API_KEY }}
       AI_NAVI_CHAT_API_TIMEOUT: ${{ secrets.AI_NAVI_CHAT_API_TIMEOUT || '30000' }}
       


### PR DESCRIPTION
## 개요
pactum-tests.yml 워크플로우에서 테스트 실행 시 API 환경을 선택할 수 있는 기능을 추가했습니다.

## 변경사항
- workflow_dispatch에 `environment` 선택 옵션 추가
  - `dev`: https://67hnjuna66.execute-api.ap-northeast-1.amazonaws.com/prd-1
  - `dev2`: https://67hnjuna66.execute-api.ap-northeast-1.amazonaws.com/dev2 (기본값)
- 선택된 환경에 따라 `AI_NAVI_CHAT_API_URL` 환경 변수가 자동으로 설정됨

## 사용 방법
1. GitHub Actions 페이지에서 "Run workflow" 클릭
2. "API 환경 선택" 드롭다운에서 원하는 환경 선택
3. 나머지 테스트 옵션 설정 후 실행

## 테스트
- [x] 워크플로우 문법 검증 완료
- [ ] dev 환경에서 테스트 실행 확인 필요
- [ ] dev2 환경에서 테스트 실행 확인 필요