### PR TITLE
AI Navi Backend Mock: SSE 스트리밍 챗 엔드포인트 구현

### DIFF
--- a/ai-navi-backend-mock/test-streaming.html
+++ b/ai-navi-backend-mock/test-streaming.html
@@ -1,0 +1,387 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <title>Streaming Chat Test - AI Navi Backend Mock</title>
+  <style>
+    body { 
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; 
+      padding: 20px;
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+    
+    .container {
+      display: flex;
+      gap: 20px;
+    }
+    
+    .panel {
+      flex: 1;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 20px;
+    }
+    
+    h1 { color: #333; }
+    h2 { color: #666; font-size: 18px; }
+    
+    .controls {
+      margin-bottom: 20px;
+      padding: 15px;
+      background: #f5f5f5;
+      border-radius: 8px;
+    }
+    
+    .control-group {
+      margin-bottom: 10px;
+    }
+    
+    label {
+      display: inline-block;
+      width: 100px;
+      font-weight: bold;
+    }
+    
+    input, select {
+      padding: 5px 10px;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      font-size: 14px;
+    }
+    
+    input[type="text"] {
+      width: 300px;
+    }
+    
+    button {
+      background: #007AFF;
+      color: white;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: 500;
+    }
+    
+    button:hover {
+      background: #0051D5;
+    }
+    
+    button:disabled {
+      background: #ccc;
+      cursor: not-allowed;
+    }
+    
+    #latency {
+      margin-top: 10px;
+      padding: 10px;
+      background: #fff3cd;
+      border: 1px solid #ffc107;
+      border-radius: 4px;
+      color: #856404;
+      font-size: 14px;
+    }
+    
+    #output {
+      white-space: pre-wrap;
+      background: #f8f9fa;
+      padding: 15px;
+      border-radius: 8px;
+      border: 1px solid #dee2e6;
+      min-height: 200px;
+      max-height: 400px;
+      overflow-y: auto;
+      font-family: 'Courier New', monospace;
+      font-size: 13px;
+      line-height: 1.5;
+    }
+    
+    .bubble-container {
+      margin-top: 20px;
+    }
+    
+    .bubble {
+      background: #007AFF;
+      color: white;
+      border-radius: 18px;
+      padding: 12px 18px;
+      margin: 10px 0;
+      display: inline-block;
+      max-width: 80%;
+      animation: slideIn 0.3s ease-out;
+      font-size: 14px;
+      line-height: 1.4;
+    }
+    
+    .bubble.main {
+      background: #007AFF;
+    }
+    
+    .bubble.sub {
+      background: #5AC8FA;
+    }
+    
+    .bubble.cta {
+      background: #FF9500;
+    }
+    
+    .bubble-type {
+      font-size: 10px;
+      text-transform: uppercase;
+      opacity: 0.8;
+      margin-bottom: 4px;
+    }
+    
+    .bubble-text {
+      font-size: 14px;
+    }
+    
+    .bubble-attachment {
+      margin-top: 8px;
+      padding-top: 8px;
+      border-top: 1px solid rgba(255,255,255,0.3);
+      font-size: 12px;
+    }
+    
+    .bubble-attachment a {
+      color: white;
+      text-decoration: underline;
+    }
+    
+    @keyframes slideIn {
+      from {
+        opacity: 0;
+        transform: translateY(10px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+    
+    .status {
+      display: inline-block;
+      padding: 4px 8px;
+      border-radius: 4px;
+      font-size: 12px;
+      font-weight: bold;
+      margin-left: 10px;
+    }
+    
+    .status.connecting { background: #ffc107; color: #856404; }
+    .status.connected { background: #28a745; color: white; }
+    .status.error { background: #dc3545; color: white; }
+    .status.done { background: #6c757d; color: white; }
+  </style>
+</head>
+<body>
+  <h1>AI Navi Backend Mock - Streaming Chat Test</h1>
+  
+  <div class="controls">
+    <div class="control-group">
+      <label>Grade ID:</label>
+      <select id="gradeSelect">
+        <option value="preschool">Preschool</option>
+        <option value="elementary">Elementary (서브 버블 포함)</option>
+        <option value="middle">Middle</option>
+        <option value="high">High</option>
+      </select>
+    </div>
+    
+    <div class="control-group">
+      <label>Message:</label>
+      <input type="text" id="messageInput" value="北海道大学を受験したいです" />
+    </div>
+    
+    <div class="control-group">
+      <label>Mock Server:</label>
+      <input type="text" id="serverUrl" value="http://localhost:3001" />
+    </div>
+    
+    <button id="sendBtn" onclick="sendStreamingRequest()">Send Streaming Request</button>
+    <span id="status" class="status"></span>
+  </div>
+  
+  <div id="latency"></div>
+  
+  <div class="container">
+    <div class="panel">
+      <h2>Raw Stream Output</h2>
+      <div id="output"></div>
+    </div>
+    
+    <div class="panel">
+      <h2>Parsed Bubbles</h2>
+      <div id="bubbles" class="bubble-container"></div>
+    </div>
+  </div>
+
+  <script>
+    let eventSource = null;
+    
+    function updateStatus(status, text) {
+      const statusEl = document.getElementById('status');
+      statusEl.className = `status ${status}`;
+      statusEl.textContent = text;
+    }
+    
+    async function sendStreamingRequest() {
+      console.log('sendStreamingRequest called');
+      const output = document.getElementById('output');
+      const latency = document.getElementById('latency');
+      const bubbles = document.getElementById('bubbles');
+      const sendBtn = document.getElementById('sendBtn');
+      
+      console.log('Elements found:', { output, latency, bubbles, sendBtn });
+      
+      // 초기화
+      output.textContent = '';
+      latency.textContent = '';
+      bubbles.innerHTML = '';
+      
+      // 기존 연결 종료
+      if (eventSource) {
+        eventSource.close();
+      }
+      
+      const gradeId = document.getElementById('gradeSelect').value;
+      const message = document.getElementById('messageInput').value;
+      const serverUrl = document.getElementById('serverUrl').value;
+      
+      sendBtn.disabled = true;
+      updateStatus('connecting', 'Connecting...');
+      
+      const start = performance.now();
+      let firstChunk = true;
+      
+      try {
+        // JWE 토큰 생성 (간단한 mock 토큰)
+        const jweToken = 'eyJhbGciOiJBMjU2S1ciLCJlbmMiOiJBMjU2R0NNIn0.mock-token-for-testing';
+        
+        console.log('Making fetch request to:', `${serverUrl}/students/chat/stream`);
+        const response = await fetch(`${serverUrl}/students/chat/stream`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-JWE-Token': jweToken
+          },
+          body: JSON.stringify({
+            clientId: 'RS000001',
+            appId: '0001',
+            gradeId: gradeId,
+            userId: 'TEST_USER',
+            message: message
+          })
+        });
+        
+        console.log('Response received:', response.status, response.statusText);
+        
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        
+        console.log('Response is OK, setting up stream reader');
+        updateStatus('connected', 'Connected');
+        
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        
+        console.log('Starting stream read loop');
+        while (true) {
+          console.log('Reading next chunk...');
+          const { done, value } = await reader.read();
+          console.log('Read result:', { done, valueLength: value ? value.length : 0 });
+          
+          if (firstChunk && value) {
+            const elapsed = Math.round(performance.now() - start);
+            latency.textContent = `첫 청크까지 대기 시간: ${elapsed}ms`;
+            firstChunk = false;
+          }
+          
+          if (done) {
+            console.log('Stream is done, breaking loop');
+            break;
+          }
+          
+          const chunk = decoder.decode(value, { stream: true });
+          console.log('Received chunk:', chunk);
+          buffer += chunk;
+          
+          // SSE 파싱
+          const lines = buffer.split('\n');
+          buffer = lines.pop() || ''; // 마지막 불완전한 라인은 버퍼에 보관
+          
+          for (const line of lines) {
+            console.log('Processing line:', line);
+            if (line.startsWith('data: ')) {
+              const data = line.slice(6);
+              console.log('SSE data:', data);
+              output.textContent += `[${new Date().toISOString()}] ${data}\n`;
+              
+              try {
+                const parsed = JSON.parse(data);
+                console.log('Parsed data:', parsed);
+                
+                if (parsed.type === 'bubble') {
+                  const bubble = parsed.data;
+                  const bubbleEl = document.createElement('div');
+                  bubbleEl.className = `bubble ${bubble.type}`;
+                  
+                  let html = `
+                    <div class="bubble-type">${bubble.type.toUpperCase()} BUBBLE</div>
+                    <div class="bubble-text">${bubble.text}</div>
+                  `;
+                  
+                  if (bubble.attachment) {
+                    html += `
+                      <div class="bubble-attachment">
+                        <strong>${bubble.attachment.title || 'Attachment'}</strong><br>
+                        <a href="${bubble.attachment.url}" target="_blank">${bubble.attachment.url}</a>
+                        ${bubble.attachment.description ? `<br>${bubble.attachment.description}` : ''}
+                      </div>
+                    `;
+                  }
+                  
+                  bubbleEl.innerHTML = html;
+                  bubbles.appendChild(bubbleEl);
+                } else if (parsed.type === 'done') {
+                  updateStatus('done', 'Stream completed');
+                  const totalElapsed = Math.round(performance.now() - start);
+                  latency.textContent += ` | 전체 수신 시간: ${totalElapsed}ms`;
+                }
+              } catch (e) {
+                console.error('Failed to parse SSE data:', e);
+              }
+            } else if (line.startsWith(':')) {
+              // 주석 또는 ping
+              output.textContent += `[PING] ${line}\n`;
+            }
+          }
+        }
+        
+      } catch (error) {
+        console.error('Streaming error:', error);
+        console.error('Error details:', {
+          name: error.name,
+          message: error.message,
+          stack: error.stack
+        });
+        updateStatus('error', `Error: ${error.message}`);
+        output.textContent += `\n[ERROR] ${error.message}`;
+      } finally {
+        sendBtn.disabled = false;
+      }
+    }
+    
+    // Enter 키로 전송
+    document.getElementById('messageInput').addEventListener('keypress', (e) => {
+      if (e.key === 'Enter' && !document.getElementById('sendBtn').disabled) {
+        sendStreamingRequest();
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## 개요
AI Navi 챗봇 응답의 체감 속도 향상을 위한 Server-Sent Events(SSE) 기반 스트리밍 응답 시스템을 구현했습니다.

## 구현내용
### 1. 스트리밍 챗 엔드포인트 추가
- `POST /students/chat/stream` 엔드포인트 구현
- SSE(Server-Sent Events) 방식으로 실시간 버블 전송
- 기존 `/students/chat`와 동일한 인증 및 유효성 검사 적용

### 2. 순차적 버블 출력 시스템
- **메인 버블**: 500ms 후 즉시 출력
- **서브 버블**: elementary 학년만 1500ms 후 출력 (조건부)
- **CTA 버블**: 서브 버블 유무에 따라 1500ms 또는 2500ms 후 출력

### 3. CORS 설정 개선
- file:// 프로토콜 및 null origin 지원 (테스트 환경)
- 동적 origin 검증 로직 구현

### 4. 테스트 환경 구축
- `test-streaming.html`: 스트리밍 동작 시각화 및 디버깅
- Raw Stream Output과 Parsed Bubbles 실시간 표시
- 지연시간 측정 및 상태 모니터링

## 적용개념
### Server-Sent Events (SSE)
- HTTP/1.1 표준 기반 실시간 스트리밍
- WebSocket보다 단순하고 HTTP 프록시 친화적
- 단방향 통신으로 챗봇 응답에 최적화

### 점진적 렌더링 (Progressive Rendering)
- TTFB(Time To First Byte) 최적화로 체감 속도 향상
- 사용자 경험 개선: 전체 응답 대기 → 버블별 즉시 표시

### 조건부 스트림 분기
- gradeId에 따른 서브 버블 포함/제외 처리
- 타이밍 최적화로 자연스러운 대화 흐름 구현

## 경험한 시행착오
### 1. 초기 CORS 문제
- **문제**: HTML 파일 직접 열기 시 `Failed to fetch` 오류
- **원인**: file:// 프로토콜의 null origin 미허용
- **해결**: 동적 origin 검증으로 null origin 허용

### 2. 스트림 조기 종료 문제
- **문제**: 첫 번째 read에서 `done: true` 반환
- **원인**: Fastify reply 헤더 설정 방식 문제
- **해결**: `reply.raw.writeHead()` 직접 사용으로 변경

### 3. 클라이언트 파싱 로직
- **문제**: SSE 데이터 파싱 시 불완전한 라인 처리
- **원인**: 청크 경계에서 데이터 분할
- **해결**: 버퍼링 로직으로 완전한 라인만 처리

## 습득한 도메인지식
### SSE 프로토콜 이해
- `data: ` 접두사와 `\n\n` 구분자의 중요성
- Keep-alive 메커니즘과 연결 관리
- 브라우저별 SSE 구현 차이점

### 스트리밍 아키텍처 설계
- 백프레셔(Backpressure) 고려사항
- 메모리 효율적인 스트림 처리
- 에러 처리 및 재연결 전략

### 사용자 경험 최적화
- 체감 성능 vs 실제 성능의 차이
- 점진적 로딩의 심리적 효과
- 타이밍 기반 자연스러운 대화 흐름

## 향후 주의사항
### 1. 프로덕션 배포 시
- CORS 설정에서 `null` origin 제거 필요
- 실제 도메인만 허용하도록 수정

### 2. 에러 처리 강화
- 네트워크 중단 시 재연결 로직
- 타임아웃 처리 및 폴백 메커니즘
- 서버 과부하 시 스트림 제한

### 3. 성능 모니터링
- 동시 연결 수 제한 고려
- 메모리 사용량 모니터링
- 지연시간 메트릭 수집

### 4. 보안 고려사항
- 스트림 하이재킹 방지
- Rate limiting 적용
- 민감 정보 로깅 방지

🤖 Generated with [Claude Code](https://claude.ai/code)