### PR TITLE
feat(slack-dev-bot): /uat1 slash command 추가

### DIFF
--- a/slack-dev-bot/README.md
+++ b/slack-dev-bot/README.md
@@ -1,9 +1,11 @@
-# Slack Dev Bot (`/dev`)
+# Slack Dev Bot (`/dev`, `/ec2`, `/uat1`)
 
-Dev 환경(ECS/CDK)을 Slack에서 관리하는 봇입니다.
+Dev / UAT1 환경(ECS/CDK)을 Slack에서 관리하는 봇입니다.
 GitHub Actions `workflow_dispatch`를 트리거하는 프록시 역할을 합니다.
 
 ## 커맨드
+
+### `/dev` (dev 환경)
 
 | 커맨드 | 설명 |
 |--------|------|
@@ -15,26 +17,57 @@ GitHub Actions `workflow_dispatch`를 트리거하는 프록시 역할을 합니
 | `/dev schedule` | 반복 스케줄 관리 |
 | `/dev help` | 사용법 안내 |
 
+### `/uat1` (UAT1 환경, 2026-05-14 신설)
+
+| 커맨드 | 설명 |
+|--------|------|
+| `/uat1` 또는 `/uat1 status` | 환경 상태 + 활성 예약 조회 |
+| `/uat1 start` | 환경 시작 (JST 18:00 이전만) |
+| `/uat1 stop` | 환경 중지 |
+| `/uat1 reserve YYYY-MM-DD [사유]` | 예약 생성 (평일만, 1일 1건) |
+| `/uat1 cancel <reservation_id>` | 예약 취소 |
+| `/uat1 help` | 사용법 안내 |
+
+UAT1 제약:
+- **평일만** 예약 (월~금) — UI 사전 차단 + DB `chk_weekday_only` 이중 가드
+- **JST 18시 이전 start 만** — UI 사전 차단 + workflow 측 거부
+- **1일 1 active 예약** — DB `uq_uat1_active_per_day` UNIQUE 제약
+
+### `/ec2` (EC2 인스턴스)
+
+`/ec2` → EC2 인스턴스 목록 + 시작/중지 버튼.
+
 ## 아키텍처
 
 ```
-Slack /dev → API Gateway → Lambda → GitHub Actions workflow_dispatch
-                                   → SSM (상태 읽기)
-                                   → Supabase (예약/배포/스케줄 CRUD)
+Slack /dev   → API Gateway → Lambda → GitHub Actions (scheduled-env-control.yml)
+Slack /uat1  → API Gateway → Lambda → GitHub Actions (uat1-env-control.yml)
+                                    → SSM (상태 읽기, dev/uat1 prefix 분리)
+                                    → Supabase (dev_*: 시간 예약 / 배포 / 스케줄,
+                                               uat1_reservations: 날짜 단위 예약)
 
-EventBridge (1분) → Lambda → Supabase 스케줄 체크 → GitHub Actions 트리거
+EventBridge (1분) → Lambda → Supabase 스케줄 체크 (dev_schedules) → GitHub Actions 트리거
+   ※ UAT1 은 GHA cron(workflow 자체) 사용 — ScheduleChecker 무관
 ```
 
 ## 사전 준비
 
 1. **GitHub Personal Access Token**: `repo`, `workflow` 스코프
-2. **Supabase**: `dev_reservations`, `pending_deployments` 테이블 (기존) + `dev_schedules` (신규)
-3. **SSM Parameter Store**: `/ai-bridge/dev/env-control/*` 파라미터 (기존 workflow에서 관리)
-4. **Slack App**: Bot Token (`xoxb-`), Signing Secret, `/dev` 슬래시 커맨드 등록
+2. **Supabase**:
+   - `dev_reservations`, `pending_deployments`, `dev_schedules` (기존)
+   - `uat1_reservations` (UAT1 — main branch)
+3. **SSM Parameter Store**:
+   - `/ai-bridge/dev/env-control/*` (dev)
+   - `/ai-bridge/uat1/env-control/*` (UAT1)
+4. **Slack App**: Bot Token (`xoxb-`), Signing Secret, 슬래시 커맨드 등록 (`/dev`, `/uat1`, `/ec2`)
+5. **GitHub Actions workflow 파일**:
+   - `scheduled-env-control.yml` (dev)
+   - `uat1-env-control.yml` (UAT1)
 
 ## Supabase 마이그레이션
 
 `migration.sql` 파일을 Supabase SQL Editor에서 실행합니다.
+UAT1 예약 테이블은 ai-bridge-infra repo 측에서 신설됨 (PR #17 참조).
 
 ## 배포
 
@@ -45,11 +78,20 @@ sam build && sam deploy --guided
 
 # 이후 배포
 sam build && sam deploy
+
+# UAT1 파라미터 명시 (선택)
+sam deploy \
+  --parameter-overrides \
+    Uat1WorkflowFile=uat1-env-control.yml \
+    Uat1SsmParameterPrefix=/ai-bridge/uat1/env-control \
+    Uat1ReservationsTable=uat1_reservations
 ```
 
 배포 후 출력되는 `SlackEventsUrl`을 Slack App 설정의 Request URL에 입력합니다.
 
 ## 환경변수 (SAM Parameters)
+
+### 공통
 
 | 파라미터 | 설명 |
 |----------|------|
@@ -58,10 +100,40 @@ sam build && sam deploy
 | `GitHubToken` | GitHub Personal Access Token |
 | `GitHubOwner` | GitHub 레포 소유자 |
 | `GitHubRepo` | GitHub 레포 이름 (기본: `ai-bridge-infra`) |
-| `GitHubWorkflowFile` | Workflow 파일명 (기본: `scheduled-env-control.yml`) |
 | `GitHubRef` | 브랜치 (기본: `main`) |
 | `SupabaseUrl` | Supabase 프로젝트 URL |
 | `SupabaseServiceRoleKey` | Supabase Service Role Key |
-| `SsmParameterPrefix` | SSM 접두사 (기본: `/ai-bridge/dev/env-control`) |
 | `AlertChannelId` | 감사 로그 채널 ID (선택) |
 | `AllowedChannelIds` | 허용 채널 ID, 쉼표 구분 (비우면 전체 허용) |
+
+### Dev 전용
+
+| 파라미터 | 설명 |
+|----------|------|
+| `GitHubWorkflowFile` | Workflow 파일명 (기본: `scheduled-env-control.yml`) |
+| `SsmParameterPrefix` | SSM 접두사 (기본: `/ai-bridge/dev/env-control`) |
+
+### UAT1 전용 (2026-05-14 신설)
+
+| 파라미터 | 기본값 | 설명 |
+|----------|--------|------|
+| `Uat1WorkflowFile` | `uat1-env-control.yml` | UAT1 GitHub Actions workflow 파일 |
+| `Uat1SsmParameterPrefix` | `/ai-bridge/uat1/env-control` | UAT1 SSM 접두사 |
+| `Uat1ReservationsTable` | `uat1_reservations` | UAT1 예약 테이블 (Supabase main branch) |
+
+### EC2 전용
+
+| 파라미터 | 기본값 | 설명 |
+|----------|--------|------|
+| `Ec2Region` | `ap-northeast-1` | EC2 리전 |
+| `Ec2NameFilter` | `devcontainer` | EC2 Name 태그 필터 |
+
+## Slack App 슬래시 커맨드 등록
+
+Workspace admin 권한으로 다음을 등록:
+
+| Command | Request URL | Description | Usage Hint |
+|---------|-------------|-------------|-----------|
+| `/dev` | (배포 후 출력된 URL) | Dev 환경 관리 | `[status\|start\|stop\|reserve\|cancel\|schedule\|help]` |
+| `/uat1` | (위와 동일 endpoint) | UAT1 환경 관리 | `[status\|start\|stop\|reserve\|cancel\|help]` |
+| `/ec2` | (위와 동일 endpoint) | EC2 인스턴스 관리 | (인자 없음) |

--- a/slack-dev-bot/src/index.js
+++ b/slack-dev-bot/src/index.js
@@ -42,6 +42,22 @@ const github = new GitHubActionsService({
   ref: process.env.GITHUB_REF || 'main',
 });
 
+// UAT1 환경용 service 인스턴스 (dev 와 동일 SupabaseService 공유)
+const ssmUat1 = new SsmService({
+  region: process.env.SSM_REGION || 'ap-northeast-1',
+  parameterPrefix: process.env.UAT1_SSM_PARAMETER_PREFIX || '/ai-bridge/uat1/env-control',
+});
+
+const githubUat1 = new GitHubActionsService({
+  token: process.env.GITHUB_TOKEN,
+  owner: process.env.GITHUB_OWNER,
+  repo: process.env.GITHUB_REPO || 'ai-bridge-infra',
+  workflowFile: process.env.UAT1_WORKFLOW_FILE || 'uat1-env-control.yml',
+  ref: process.env.GITHUB_REF || 'main',
+});
+
+const uat1ReservationsTable = process.env.UAT1_RESERVATIONS_TABLE || 'uat1_reservations';
+
 const scheduleChecker = new ScheduleChecker({
   supabaseService: supabase,
   githubService: github,
@@ -456,6 +472,246 @@ async function sendAuditLog(client, userId, action, logger) {
     logger.error('감사 로그 전송 실패 (무시됨):', error.message);
   }
 }
+
+async function sendUat1AuditLog(client, userId, action, detail, logger) {
+  if (!alertChannelId) return;
+  try {
+    const verbMap = { start: '시작', stop: '중지', reserve: '예약', cancel: '예약 취소' };
+    const verb = verbMap[action] || action;
+    await client.chat.postMessage({
+      channel: alertChannelId,
+      blocks: ui.uat1AlertMessage(userId, action, detail),
+      text: `UAT1 환경 ${verb} — by <@${userId}>`,
+    });
+  } catch (error) {
+    logger.error('UAT1 감사 로그 전송 실패 (무시됨):', error.message);
+  }
+}
+
+// ──────────────────────────────────────────
+// /uat1 슬래시 커맨드
+// ──────────────────────────────────────────
+
+const JST_BUSINESS_HOUR_LIMIT = 18; // JST 18시 이후 start 차단
+
+function nowInJst() {
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Asia/Tokyo',
+    hour12: false,
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit',
+  }).formatToParts(new Date());
+  const get = (type) => parseInt(fmt.find((p) => p.type === type).value, 10);
+  return { hour: get('hour'), minute: get('minute') };
+}
+
+function isWeekdayDateString(dateStr) {
+  // YYYY-MM-DD (로컬 해석 회피 위해 UTC 자정으로 파싱)
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return false;
+  const d = new Date(`${dateStr}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return false;
+  const day = d.getUTCDay(); // 0=일, 1=월, ..., 6=토
+  return day >= 1 && day <= 5;
+}
+
+function parseUat1ReserveText(text) {
+  // 'reserve YYYY-MM-DD 사유...' 또는 'reserve YYYY-MM-DD'
+  const trimmed = (text || '').trim().replace(/^reserve\s+/, '');
+  const match = trimmed.match(/^(\d{4}-\d{2}-\d{2})(?:\s+(.+))?$/);
+  if (!match) return { date: null, reason: null };
+  return { date: match[1], reason: match[2] || null };
+}
+
+function parseUat1CancelText(text) {
+  // 'cancel <id>' → uuid 만 추출
+  return (text || '').trim().replace(/^cancel\s+/, '').trim() || null;
+}
+
+app.command('/uat1', async ({ command, ack, respond, client, logger }) => {
+  await ack();
+
+  if (!isChannelAllowed(command.channel_id)) {
+    await respond({ response_type: 'ephemeral', text: '이 채널에서는 /uat1 커맨드를 사용할 수 없습니다.' });
+    return;
+  }
+
+  const text = (command.text || '').trim();
+  const subcommand = text.split(/\s+/)[0].toLowerCase();
+
+  try {
+    switch (subcommand) {
+      case '':
+      case 'status':
+        await handleUat1Status(respond, logger);
+        break;
+      case 'start':
+        await handleUat1Start(command, respond, client, logger);
+        break;
+      case 'stop':
+        await handleUat1Stop(command, respond, client, logger);
+        break;
+      case 'reserve':
+        await handleUat1Reserve(command, text, respond, client, logger);
+        break;
+      case 'cancel':
+        await handleUat1Cancel(command, text, respond, client, logger);
+        break;
+      case 'help':
+        await respond({ response_type: 'ephemeral', blocks: ui.uat1HelpMessage() });
+        break;
+      default:
+        await respond({ response_type: 'ephemeral', text: `알 수 없는 명령어: \`${subcommand}\`\n\`/uat1 help\`로 사용법을 확인하세요.` });
+    }
+  } catch (error) {
+    logger.error(`/uat1 ${subcommand} 처리 실패:`, error);
+    await respond({ response_type: 'ephemeral', text: `처리 중 오류가 발생했습니다: ${error.message}` });
+  }
+});
+
+// ──────────────────────────────────────────
+// /uat1 서브커맨드 핸들러
+// ──────────────────────────────────────────
+
+async function handleUat1Status(respond, logger) {
+  const [envStatus, reservations] = await Promise.all([
+    ssmUat1.getEnvStatus().catch((e) => { logger.error('UAT1 SSM 조회 실패:', e); return { status: 'unknown' }; }),
+    supabase.getActiveUat1Reservations(uat1ReservationsTable).catch((e) => { logger.error('UAT1 예약 조회 실패:', e); return []; }),
+  ]);
+
+  const blocks = ui.uat1StatusView(envStatus, reservations);
+  await respond({ response_type: 'in_channel', blocks });
+}
+
+async function handleUat1Start(command, respond, client, logger) {
+  const { hour } = nowInJst();
+  if (hour >= JST_BUSINESS_HOUR_LIMIT) {
+    await respond({
+      response_type: 'ephemeral',
+      text: `:warning: UAT1 start 는 JST 18시 이전만 가능합니다 (현재 JST ${String(hour).padStart(2, '0')}시).`,
+    });
+    return;
+  }
+
+  await githubUat1.triggerWorkflow('start');
+  await respond({ response_type: 'in_channel', blocks: ui.uat1ResultMessage('start', true) });
+  await sendUat1AuditLog(client, command.user_id, 'start', null, logger);
+}
+
+async function handleUat1Stop(command, respond, client, logger) {
+  await githubUat1.triggerWorkflow('stop');
+  await respond({ response_type: 'in_channel', blocks: ui.uat1ResultMessage('stop', true) });
+  await sendUat1AuditLog(client, command.user_id, 'stop', null, logger);
+}
+
+async function handleUat1Reserve(command, text, respond, client, logger) {
+  const { date, reason } = parseUat1ReserveText(text);
+  if (!date) {
+    await respond({
+      response_type: 'ephemeral',
+      text: '사용법: `/uat1 reserve YYYY-MM-DD [사유]` (평일만)',
+    });
+    return;
+  }
+  if (!isWeekdayDateString(date)) {
+    await respond({
+      response_type: 'ephemeral',
+      text: `:warning: UAT1 예약은 평일(월~금) 만 가능합니다 — ${date} 는 주말입니다.`,
+    });
+    return;
+  }
+
+  try {
+    await supabase.createUat1Reservation(
+      { reservation_date: date, reserved_by: command.user_id, reserved_via: 'slack', reason },
+      uat1ReservationsTable,
+    );
+    await respond({
+      response_type: 'in_channel',
+      blocks: ui.uat1ReserveResultMessage(command.user_id, date, reason, true),
+    });
+    await sendUat1AuditLog(client, command.user_id, 'reserve', date, logger);
+  } catch (error) {
+    logger.error('UAT1 예약 생성 실패:', error);
+    await respond({
+      response_type: 'ephemeral',
+      blocks: ui.uat1ReserveResultMessage(command.user_id, date, reason, false, error.message),
+    });
+  }
+}
+
+async function handleUat1Cancel(command, text, respond, client, logger) {
+  const id = parseUat1CancelText(text);
+  if (!id) {
+    await respond({
+      response_type: 'ephemeral',
+      text: '사용법: `/uat1 cancel <reservation_id>` (예약 ID 는 `/uat1 status` 에서 확인)',
+    });
+    return;
+  }
+  try {
+    await supabase.cancelUat1Reservation(id, command.user_id, uat1ReservationsTable);
+    await respond({ response_type: 'in_channel', blocks: ui.uat1ResultMessage('cancel', true) });
+    await sendUat1AuditLog(client, command.user_id, 'cancel', id, logger);
+  } catch (error) {
+    logger.error('UAT1 예약 취소 실패:', error);
+    await respond({ response_type: 'ephemeral', blocks: ui.uat1ResultMessage('cancel', false, error.message) });
+  }
+}
+
+// ──────────────────────────────────────────
+// /uat1 버튼 액션 핸들러
+// ──────────────────────────────────────────
+
+app.action('uat1_start', async ({ body, ack, respond, client, logger }) => {
+  await ack();
+  try {
+    const { hour } = nowInJst();
+    if (hour >= JST_BUSINESS_HOUR_LIMIT) {
+      await respond({
+        response_type: 'ephemeral',
+        replace_original: false,
+        text: `:warning: UAT1 start 는 JST 18시 이전만 가능합니다 (현재 JST ${String(hour).padStart(2, '0')}시).`,
+      });
+      return;
+    }
+    await githubUat1.triggerWorkflow('start');
+    await respond({ response_type: 'in_channel', replace_original: false, blocks: ui.uat1ResultMessage('start', true) });
+    await sendUat1AuditLog(client, body.user.id, 'start', null, logger);
+  } catch (error) {
+    logger.error('UAT1 시작 실패:', error);
+    await respond({ response_type: 'in_channel', replace_original: false, blocks: ui.uat1ResultMessage('start', false, error.message) });
+  }
+});
+
+app.action('uat1_stop', async ({ body, ack, respond, client, logger }) => {
+  await ack();
+  try {
+    await githubUat1.triggerWorkflow('stop');
+    await respond({ response_type: 'in_channel', replace_original: false, blocks: ui.uat1ResultMessage('stop', true) });
+    await sendUat1AuditLog(client, body.user.id, 'stop', null, logger);
+  } catch (error) {
+    logger.error('UAT1 중지 실패:', error);
+    await respond({ response_type: 'in_channel', replace_original: false, blocks: ui.uat1ResultMessage('stop', false, error.message) });
+  }
+});
+
+app.action('uat1_refresh', async ({ ack, respond, logger }) => {
+  await ack();
+  await handleUat1Status(respond, logger);
+});
+
+app.action(/^uat1_cancel_(.+)$/, async ({ action, body, ack, respond, client, logger }) => {
+  await ack();
+  const reservationId = action.action_id.replace('uat1_cancel_', '');
+  try {
+    await supabase.cancelUat1Reservation(reservationId, body.user.id, uat1ReservationsTable);
+    await respond({ response_type: 'ephemeral', replace_original: false, blocks: ui.uat1ResultMessage('cancel', true) });
+    await sendUat1AuditLog(client, body.user.id, 'cancel', reservationId, logger);
+  } catch (error) {
+    logger.error('UAT1 예약 취소 실패:', error);
+    await respond({ response_type: 'ephemeral', replace_original: false, blocks: ui.uat1ResultMessage('cancel', false, error.message) });
+  }
+});
 
 // ──────────────────────────────────────────
 // 글로벌 에러 핸들러

--- a/slack-dev-bot/src/services/SupabaseService.js
+++ b/slack-dev-bot/src/services/SupabaseService.js
@@ -165,6 +165,86 @@ class SupabaseService {
       .eq('id', id);
     if (error) throw error;
   }
+
+  // ──────────────────────────────────────────
+  // uat1_reservations (UAT1 환경 예약)
+  //
+  // 스키마: id UUID, reservation_date DATE, reserved_by, reserved_via,
+  // reason, status (active/cancelled/completed), created_at, updated_at,
+  // cancelled_at, cancelled_by
+  // 제약: chk_weekday_only (월~금만), chk_status_enum,
+  //       uq_uat1_active_per_day (1일 1 active)
+  // ──────────────────────────────────────────
+
+  /**
+   * UAT1 활성 예약 목록을 조회한다.
+   * @param {string} [tableName] - 기본 'uat1_reservations'. env 로 override 가능.
+   */
+  async getActiveUat1Reservations(tableName = 'uat1_reservations') {
+    const { data, error } = await this.supabase
+      .from(tableName)
+      .select('*')
+      .eq('status', 'active')
+      .order('reservation_date', { ascending: true });
+    if (error) throw error;
+    return data || [];
+  }
+
+  /**
+   * UAT1 예약 단건 조회 (ID).
+   * @param {string} id
+   * @param {string} [tableName]
+   */
+  async getUat1Reservation(id, tableName = 'uat1_reservations') {
+    const { data, error } = await this.supabase
+      .from(tableName)
+      .select('*')
+      .eq('id', id)
+      .maybeSingle();
+    if (error) throw error;
+    return data || null;
+  }
+
+  /**
+   * UAT1 예약을 생성한다.
+   * @param {{ reservation_date: string, reserved_by: string, reserved_via?: string, reason?: string }} reservation
+   * @param {string} [tableName]
+   */
+  async createUat1Reservation(reservation, tableName = 'uat1_reservations') {
+    const payload = {
+      reservation_date: reservation.reservation_date,
+      reserved_by: reservation.reserved_by,
+      reserved_via: reservation.reserved_via || 'slack',
+      reason: reservation.reason || null,
+      status: 'active',
+    };
+    const { data, error } = await this.supabase
+      .from(tableName)
+      .insert(payload)
+      .select()
+      .single();
+    if (error) throw error;
+    return data;
+  }
+
+  /**
+   * UAT1 예약을 취소한다.
+   * @param {string} id - 예약 ID
+   * @param {string} [cancelledBy] - 취소한 Slack user_id
+   * @param {string} [tableName]
+   */
+  async cancelUat1Reservation(id, cancelledBy = null, tableName = 'uat1_reservations') {
+    const patch = {
+      status: 'cancelled',
+      cancelled_at: new Date().toISOString(),
+    };
+    if (cancelledBy) patch.cancelled_by = cancelledBy;
+    const { error } = await this.supabase
+      .from(tableName)
+      .update(patch)
+      .eq('id', id);
+    if (error) throw error;
+  }
 }
 
 module.exports = SupabaseService;

--- a/slack-dev-bot/src/ui/SlackUI.js
+++ b/slack-dev-bot/src/ui/SlackUI.js
@@ -560,6 +560,110 @@ class SlackUI {
   }
 
   // ──────────────────────────────────────────
+  // /uat1 (UAT1 환경 관리)
+  // ──────────────────────────────────────────
+
+  uat1HelpMessage() {
+    return [
+      { type: 'header', text: { type: 'plain_text', text: 'UAT1 환경 관리 — /uat1' } },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: [
+            '*사용 가능한 명령:*',
+            '• `/uat1` 또는 `/uat1 status` — 현재 상태 + 활성 예약 조회',
+            '• `/uat1 start` — 환경 시작 (평일 18:00 JST 이전만)',
+            '• `/uat1 stop` — 환경 중지',
+            '• `/uat1 reserve YYYY-MM-DD [사유]` — 예약 생성 (평일, 1일 1건)',
+            '• `/uat1 cancel <reservation_id>` — 예약 취소',
+            '• `/uat1 help` — 이 메시지',
+            '',
+            ':warning: UAT1 제약 — 평일(월~금)만 예약 가능, JST 18시 이후 start 차단, 1일 1 active 예약',
+          ].join('\n'),
+        },
+      },
+    ];
+  }
+
+  uat1StatusView(envStatus, reservations) {
+    const statusEmoji = { running: ':large_green_circle:', stopped: ':red_circle:', starting: ':large_yellow_circle:', stopping: ':large_yellow_circle:', unknown: ':grey_question:' };
+    const emoji = statusEmoji[envStatus.status] || ':grey_question:';
+
+    const blocks = [
+      { type: 'header', text: { type: 'plain_text', text: 'UAT1 환경 상태' } },
+      {
+        type: 'section',
+        fields: [
+          { type: 'mrkdwn', text: `*상태:* ${emoji} \`${envStatus.status}\`` },
+          { type: 'mrkdwn', text: `*마지막 액션:* ${envStatus.lastAction || 'N/A'}` },
+          { type: 'mrkdwn', text: `*시각:* ${this._formatTime(envStatus.lastActionTime)}` },
+          { type: 'mrkdwn', text: `*실행자:* ${envStatus.lastActionBy ? `<@${envStatus.lastActionBy}>` : 'N/A'}` },
+        ],
+      },
+      {
+        type: 'actions',
+        elements: [
+          { type: 'button', text: { type: 'plain_text', text: '시작' }, style: 'primary', action_id: 'uat1_start', confirm: { title: { type: 'plain_text', text: 'UAT1 시작' }, text: { type: 'plain_text', text: '환경을 시작하시겠습니까?' }, confirm: { type: 'plain_text', text: '확인' }, deny: { type: 'plain_text', text: '취소' } } },
+          { type: 'button', text: { type: 'plain_text', text: '중지' }, style: 'danger', action_id: 'uat1_stop', confirm: { title: { type: 'plain_text', text: 'UAT1 중지' }, text: { type: 'plain_text', text: '환경을 중지하시겠습니까?' }, confirm: { type: 'plain_text', text: '확인' }, deny: { type: 'plain_text', text: '취소' } } },
+          { type: 'button', text: { type: 'plain_text', text: '새로고침' }, action_id: 'uat1_refresh' },
+        ],
+      },
+      { type: 'divider' },
+    ];
+
+    if (reservations.length > 0) {
+      blocks.push({ type: 'section', text: { type: 'mrkdwn', text: `*활성 예약 (${reservations.length}건):*` } });
+      reservations.forEach((r) => {
+        blocks.push({
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: [
+              `*${r.reservation_date}* — by <@${r.reserved_by}>`,
+              r.reason ? `사유: ${r.reason}` : '',
+              `\`${r.id}\``,
+            ].filter(Boolean).join('\n'),
+          },
+          accessory: { type: 'button', text: { type: 'plain_text', text: '취소' }, style: 'danger', action_id: `uat1_cancel_${r.id}`, value: r.id },
+        });
+      });
+    } else {
+      blocks.push({ type: 'section', text: { type: 'mrkdwn', text: '_활성 예약 없음_' } });
+    }
+
+    return blocks;
+  }
+
+  uat1ResultMessage(action, success, error = null) {
+    const verbMap = { start: '시작', stop: '중지', reserve: '예약', cancel: '예약 취소' };
+    const verb = verbMap[action] || action;
+    if (success) {
+      return [{ type: 'section', text: { type: 'mrkdwn', text: `:white_check_mark: UAT1 환경 ${verb} 요청 완료` } }];
+    }
+    return [{ type: 'section', text: { type: 'mrkdwn', text: `:x: UAT1 환경 ${verb} 실패\n\`\`\`${error || '알 수 없는 오류'}\`\`\`` } }];
+  }
+
+  uat1AlertMessage(userId, action, detail = null) {
+    const verbMap = { start: '시작', stop: '중지', reserve: '예약', cancel: '예약 취소' };
+    const verb = verbMap[action] || action;
+    const tail = detail ? ` (${detail})` : '';
+    return [{ type: 'section', text: { type: 'mrkdwn', text: `:memo: <@${userId}>님이 UAT1 환경을 ${verb}했습니다${tail}.` } }];
+  }
+
+  uat1ReserveResultMessage(userId, reservationDate, reason, success, error = null) {
+    if (success) {
+      const text = [
+        `:white_check_mark: <@${userId}>님이 UAT1 예약을 생성했습니다.`,
+        `날짜: *${reservationDate}*`,
+        reason ? `사유: ${reason}` : '',
+      ].filter(Boolean).join('\n');
+      return [{ type: 'section', text: { type: 'mrkdwn', text } }];
+    }
+    return [{ type: 'section', text: { type: 'mrkdwn', text: `:x: UAT1 예약 생성 실패\n\`\`\`${error || '알 수 없는 오류'}\`\`\`` } }];
+  }
+
+  // ──────────────────────────────────────────
   // 내부 헬퍼
   // ──────────────────────────────────────────
 

--- a/slack-dev-bot/template.yaml
+++ b/slack-dev-bot/template.yaml
@@ -47,6 +47,18 @@ Parameters:
     Type: String
     Default: /ai-bridge/dev/env-control
     Description: SSM Parameter Store 접두사
+  Uat1WorkflowFile:
+    Type: String
+    Default: uat1-env-control.yml
+    Description: UAT1 환경 GitHub Actions workflow 파일명
+  Uat1SsmParameterPrefix:
+    Type: String
+    Default: /ai-bridge/uat1/env-control
+    Description: UAT1 SSM Parameter Store 접두사
+  Uat1ReservationsTable:
+    Type: String
+    Default: uat1_reservations
+    Description: UAT1 예약 테이블명 (Supabase main branch)
   AlertChannelId:
     Type: String
     Default: ''
@@ -83,6 +95,9 @@ Resources:
           SUPABASE_URL: !Ref SupabaseUrl
           SUPABASE_SERVICE_ROLE_KEY: !Ref SupabaseServiceRoleKey
           SSM_PARAMETER_PREFIX: !Ref SsmParameterPrefix
+          UAT1_WORKFLOW_FILE: !Ref Uat1WorkflowFile
+          UAT1_SSM_PARAMETER_PREFIX: !Ref Uat1SsmParameterPrefix
+          UAT1_RESERVATIONS_TABLE: !Ref Uat1ReservationsTable
           ALERT_CHANNEL_ID: !Ref AlertChannelId
           ALLOWED_CHANNEL_IDS: !Ref AllowedChannelIds
           EC2_REGION: !Ref Ec2Region
@@ -92,7 +107,9 @@ Resources:
             - Effect: Allow
               Action:
                 - ssm:GetParameter
-              Resource: !Sub 'arn:aws:ssm:ap-northeast-1:${AWS::AccountId}:parameter${SsmParameterPrefix}/*'
+              Resource:
+                - !Sub 'arn:aws:ssm:ap-northeast-1:${AWS::AccountId}:parameter${SsmParameterPrefix}/*'
+                - !Sub 'arn:aws:ssm:ap-northeast-1:${AWS::AccountId}:parameter${Uat1SsmParameterPrefix}/*'
             - Effect: Allow
               Action:
                 - ec2:DescribeInstances


### PR DESCRIPTION
## Summary

UAT1 환경 (`ai-bridge-bff-uat1.meeta.jp`, 2026-05-14 신설) 관리를 위한 `/uat1` 슬래시 커맨드를 `slack-dev-bot` 에 추가합니다. 기존 `/dev` 와 동일한 sub-command 패턴 (`status` / `start` / `stop` / `reserve` / `cancel` / `help`).

원본 작업 프롬프트: `ai-bridge-workspace/docs/plans/uat1-slack-command/prompt-for-other-session.md` (다른 세션 입력용으로 작성된 spec).

## 변경 파일 (5건, +542 / -13)

| 파일 | 변경 |
|------|------|
| `template.yaml` | Parameters 3 + Function ENV 3 + SSM IAM resource 확장 |
| `src/services/SupabaseService.js` | UAT1 예약 메서드 4종 (테이블명 인자) |
| `src/ui/SlackUI.js` | UAT1 뷰 5종 (help, status, result, alert, reserveResult) |
| `src/index.js` | UAT1 service 인스턴스 + `/uat1` 핸들러 + 4 액션 + 헬퍼 + 감사 로그 |
| `README.md` | `/uat1` 커맨드 + UAT1 파라미터 + Slack app 등록 가이드 |

## UAT1 제약 (UI 사전 차단 + DB 이중 가드)

- **평일만 예약** (월~금) — `isWeekdayDateString()` + DB `chk_weekday_only`
- **JST 18시 이전 start 만** — `nowInJst()` + workflow 측 거부
- **1일 1 active 예약** — DB `uq_uat1_active_per_day` UNIQUE
- **예약 모달 X** — `/uat1 reserve YYYY-MM-DD [사유]` 텍스트 인자 모드
- **취소도 텍스트 인자** — `/uat1 cancel <reservation_id>` (또는 status 카드의 버튼)

## 검증 기준 (배포 후 Slack)

1. `/uat1 help` → 사용법 안내 응답
2. `/uat1 status` → ECS desired/running + SSM state 응답
3. `/uat1 reserve 2026-05-19 통합테스트` (평일) → DB INSERT + 알림
4. `/uat1 reserve 2026-05-17` (토) → UI 차단 (메시지 표시)
5. `/uat1 start` (평일 18시 이전) → workflow 트리거, 5분 후 BFF 200
6. `/uat1 stop` → ECS desired=0, BFF 503
7. `/uat1 cancel <id>` → DB row status=cancelled

## Test plan

- [ ] `node --check src/index.js` 통과 (✅ syntax OK 확인 완료)
- [ ] `sam build` 통과
- [ ] `sam deploy --parameter-overrides Uat1WorkflowFile=uat1-env-control.yml Uat1SsmParameterPrefix=/ai-bridge/uat1/env-control Uat1ReservationsTable=uat1_reservations` 통과
- [ ] Slack workspace admin: `/uat1` 슬래시 커맨드 등록 (Request URL 은 기존 `/dev` 와 동일 endpoint)
- [ ] 검증 기준 1~7 통과
- [ ] `/dev` 회귀 (regression) — 기존 동작 미변경 확인

## 참조

- `meeta-inc/ai-bridge-infra#17` — UAT1 CDK config + 2 workflow 신설
- `meeta-inc/ai-bridge-infra#22` — `uat1-env-control.yml` Slack 알림
- `meeta-inc/ai-bridge-infra#23` — Slack 알림에 JST 시각
- `meeta-inc/ai-bridge-workspace` — `docs/plans/uat1-slack-command/prompt-for-other-session.md` (이 PR 의 원본 spec)

## 외부 의존 (이번 PR 후)

- AWS SAM 배포 (위 `Test plan` §3)
- Slack workspace admin: `/uat1` slash command 등록
- `docs/operations/uat1-resources.md §7` 에 `/uat1` 명령 표 추가 (ai-bridge-workspace 측)

🤖 Generated with [Claude Code](https://claude.com/claude-code)